### PR TITLE
O.a. Opmerking stopzetten doorontwikkeling

### DIFF
--- a/docs/ICT aanbod.md
+++ b/docs/ICT aanbod.md
@@ -23,8 +23,3 @@ Dit overzicht is ook te bereiken via deze directe link.
 
 ## Staat uw huidige softwareproduct niet in het overzicht?
 Neem in dit geval contact op met de Softwareleverancier, of de Gebruikersvereniging om de GEMMA Softwarecatalogus te laten actualiseren of de standaard te laten inbouwen. De leverancier is er zelf verantwoordelijk voor het actueel houden van de GEMMA Softwarecatalogus.
-
-## Hoe borg ik dat het koppelvlak ook daadwerkelijk wordt geleverd?
-VNG-Realisatie heeft de [Handreiking leverings- en acceptatievoorwaarden ICT](documenten/130131_Leverings_en_acceptatievoorwaarden_versie_2_Definitief.pdf) opgesteld. Dit document biedt u een set van artikelen die u geheel of gedeeltelijk kunt inweven in eigen inkoop- en acceptatievoorwaarden ICT. Hiermee borgt u dat in de uitvraag expliciet wordt gevraagd om het leveren van de standaard en het voldoen aan de compliancy.
-
-Meer informatie hierover leest u op de pagina ICT-opdrachtgeverschap van Operatie NUP en VNG-Realisatie.

--- a/docs/Opdrachtgeverschap.md
+++ b/docs/Opdrachtgeverschap.md
@@ -6,14 +6,4 @@ title: Opdrachtgeverschap Prefill eFormulierenservices
 
 ## Hoe borg ik dat het koppelvlak ook daadwerkelijk wordt geleverd?
 
-VNG Realisatie heeft de [Handreiking leverings- en acceptatievoorwaarden
-ICT](./documenten/130131_Leverings_en_acceptatievoorwaarden_versie_2_Definitief.pdf)
-opgesteld. Dit document biedt u een set van artikelen die u geheel of
-gedeeltelijk kunt inweven in eigen inkoop- en acceptatievoorwaarden ICT.
-Hiermee borgt u dat in de uitvraag expliciet wordt gevraagd om het
-leveren van de standaard en het voldoen aan de compliancy. Meer
-informatie hierover leest u op de pagina's
-<span style="color:red">Leveranciersmanagement<!--[Leveranciersmanagement](https://www.vngrealisatie.nl/onderwerpen/leveranciersmanagement)--></span>
-op de VNG Realisatie-website en
-[Inkoopondersteuning](https://www.softwarecatalogus.nl/purchase-support)
-in de GEMMA Softwarecatalogus.
+VNG Realisatie helpt gemeenten met de 'Gemeentelijke Inkoop bij IT Toolbox'([GIBIT](https://vng.nl/projecten/gibit)) bij het professionaliseren van de inkoop van ICT-diensten en –producten. De GIBIT-Toolbox levert hiervoor de basis. Hiermee borgt u dat in de uitvraag expliciet wordt gevraagd om het leveren van de standaard en het voldoen aan de compliancy.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,5 +13,14 @@ Verschillende ontwikkelingen maken het vernieuwen van standaarden noodzakelijk o
 
 **RSGB bevragingen** is een uitbreiding van de prefill eFormulierservices. Het is een berichtenstandaard voor het opvragen van gegevens zoals beschreven in het RSGB. Het bevat de berichtspecificaties van de meest gebruikte bevragingen in het gemeentedomein.
 
-## Discussieplatform
-Hier kunt u terecht voor de nieuwste discussies m.b.t. [Prefill eFormulierenservices en RSGB Bevragingen](https://github.com/VNG-Realisatie/StUF-Standaarden/issues?q=is%3Aopen+is%3Aissue+label%3A%22Koppelvlak+-+PRS%22).
+## Community voor vragen en wijzigingsverzoeken
+
+Het kan voorkomen dat er nog onduidelijkheden zijn in de
+standaard Prefill eFormulierenservices en RSGB Bevragingen. Daarvoor is op Github een
+[community](https://github.com/VNG-Realisatie/StUF-Standaarden/issues?q=is%3Aopen+is%3Aissue+label%3A%22Koppelvlak+-+PRS%22)
+beschikbaar gesteld waar u vragen kunt stellen door een issue aan te
+maken. Middels het label ‘Koppelvlak - PRS’ kunt u het issue
+vervolgens aan deze standaard koppelen.
+
+Zowel VNG Realisatie als leveranciers en gemeenten kunnen dan online
+reageren op de vraag en deze beantwoorden.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,8 @@ title: Prefill eFormulierenservices
 **Actuele versie:** 1.0
 **Beheerder:**  VNG Realisatie 
 
+Verschillende ontwikkelingen maken het vernieuwen van standaarden noodzakelijk om invulling te (blijven) geven aan de behoefte en wensen van gemeenten. De doorontwikkeling van de StUF standaard, de StUF sectormodellen en de StUF koppelvlakken waaronder deze Prefill eFormulierservices is daarom stopgezet. Alleen wetswijzigingen, wijzigingen in de Logische Ontwerpen van Basisregistraties en gevonden fouten kunnen aanleiding zijn voor het publiceren van een nieuwe versie van deze standaarden. Zo wordt er voor gezorgd dat gemeenten hun werk kunnen blijven doen. Een toelichting op het vernieuwen van de standaarden is te vinden bij API-standaarden.
+
 **Prefill eFormulierservices** is een op [StUF-BG 3.10](https://vng-realisatie.github.io/StUF-BG/) gebaseerde berichtenstandaard voor de uitwisseling van de gegevens ten behoeve van het voorinvullen van <span style="color:red">GEMMA e-formulieren</span>. De standaard gaat er vanuit dat er een (internet) applicatie is welke invulbare formulieren aanbiedt aan een burger. Deze formulieren worden vooraf zover als mogelijk ingevuld met de gegevens die al bekend zijn in de eigen administratie. Vraag naar deze standaard bij uw leverancier.
 
 **RSGB bevragingen** is een uitbreiding van de prefill eFormulierservices. Het is een berichtenstandaard voor het opvragen van gegevens zoals beschreven in het RSGB. Het bevat de berichtspecificaties van de meest gebruikte bevragingen in het gemeentedomein.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,11 +7,12 @@ title: Prefill eFormulierenservices
 **Actuele versie:** 1.0
 **Beheerder:**  VNG Realisatie 
 
-Verschillende ontwikkelingen maken het vernieuwen van standaarden noodzakelijk om invulling te (blijven) geven aan de behoefte en wensen van gemeenten. De doorontwikkeling van de StUF standaard, de StUF sectormodellen en de StUF koppelvlakken waaronder deze Prefill eFormulierservices is daarom stopgezet. Alleen wetswijzigingen, wijzigingen in de Logische Ontwerpen van Basisregistraties en gevonden fouten kunnen aanleiding zijn voor het publiceren van een nieuwe versie van deze standaarden. Zo wordt er voor gezorgd dat gemeenten hun werk kunnen blijven doen. Een toelichting op het vernieuwen van de standaarden is te vinden bij API-standaarden.
-
 **Prefill eFormulierservices** is een op [StUF-BG 3.10](https://vng-realisatie.github.io/StUF-BG/) gebaseerde berichtenstandaard voor de uitwisseling van de gegevens ten behoeve van het voorinvullen van <span style="color:red">GEMMA e-formulieren</span>. De standaard gaat er vanuit dat er een (internet) applicatie is welke invulbare formulieren aanbiedt aan een burger. Deze formulieren worden vooraf zover als mogelijk ingevuld met de gegevens die al bekend zijn in de eigen administratie. Vraag naar deze standaard bij uw leverancier.
 
 **RSGB bevragingen** is een uitbreiding van de prefill eFormulierservices. Het is een berichtenstandaard voor het opvragen van gegevens zoals beschreven in het RSGB. Het bevat de berichtspecificaties van de meest gebruikte bevragingen in het gemeentedomein.
+
+## Status en doorontwikkeling
+Verschillende ontwikkelingen maken het vernieuwen van standaarden noodzakelijk om invulling te (blijven) geven aan de behoefte en wensen van gemeenten. De doorontwikkeling van de StUF standaard, de StUF sectormodellen en de StUF koppelvlakken waaronder deze Prefill eFormulierservices is daarom stopgezet. Alleen wetswijzigingen, wijzigingen in de Logische Ontwerpen van Basisregistraties en gevonden fouten kunnen aanleiding zijn voor het publiceren van een nieuwe versie van deze standaarden. Zo wordt er voor gezorgd dat gemeenten hun werk kunnen blijven doen. Een toelichting op het vernieuwen van de standaarden is te vinden bij API-standaarden.
 
 ## Community voor vragen en wijzigingsverzoeken
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ title: Prefill eFormulierenservices
 **RSGB bevragingen** is een uitbreiding van de prefill eFormulierservices. Het is een berichtenstandaard voor het opvragen van gegevens zoals beschreven in het RSGB. Het bevat de berichtspecificaties van de meest gebruikte bevragingen in het gemeentedomein.
 
 ## Status en doorontwikkeling
-Verschillende ontwikkelingen maken het vernieuwen van standaarden noodzakelijk om invulling te (blijven) geven aan de behoefte en wensen van gemeenten. De doorontwikkeling van de StUF standaard, de StUF sectormodellen en de StUF koppelvlakken waaronder deze Prefill eFormulierservices is daarom stopgezet. Alleen wetswijzigingen, wijzigingen in de Logische Ontwerpen van Basisregistraties en gevonden fouten kunnen aanleiding zijn voor het publiceren van een nieuwe versie van deze standaarden. Zo wordt er voor gezorgd dat gemeenten hun werk kunnen blijven doen. Een toelichting op het vernieuwen van de standaarden is te vinden bij API-standaarden.
+Verschillende ontwikkelingen maken het vernieuwen van standaarden noodzakelijk om invulling te (blijven) geven aan de behoefte en wensen van gemeenten. De doorontwikkeling van de StUF standaard, de StUF sectormodellen en de StUF koppelvlakken waaronder deze Prefill eFormulierservices is daarom stopgezet. Alleen wetswijzigingen, wijzigingen in de Logische Ontwerpen van Basisregistraties en gevonden fouten kunnen aanleiding zijn voor het publiceren van een nieuwe versie van deze standaarden. Zo wordt er voor gezorgd dat gemeenten hun werk kunnen blijven doen. Een toelichting op het vernieuwen van de standaarden is te vinden bij [API-standaarden](https://vng-realisatie.github.io/Standaarden/API-standaarden).
 
 ## Community voor vragen en wijzigingsverzoeken
 


### PR DESCRIPTION
* Paragraaf over borging staat ook in 'Opdrachtgeverschap.md' en is in 'ICT aanbod.md' dus verwijderd.
* Opmerking over de stopzetting van de doorontwikkeling toegevoegd aan 'Overzicht.md'.
* Paragraaf over Discussieplatform gewijzigd